### PR TITLE
Use POST on /tenant to ensure tenant exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Example:
 
 [DEFAULT]
 pip
+
 ```ini
 ApiKey = <ApiKey>
 Url = localhost
-Tenant = <TenantName>
 ```
 
 ### Sections

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Script for initialization of the [BringAuto Fleet Management] database - Script 
 Example:
 
 [DEFAULT]
-
-```
+pip
+```ini
 ApiKey = <ApiKey>
 Url = localhost
 Tenant = <TenantName>

--- a/config/config.ini
+++ b/config/config.ini
@@ -1,4 +1,3 @@
 [DEFAULT]
 ApiKey = <ApiKey>
 Url = 127.0.0.1:8080/v2/management
-Tenant = <TenantName>

--- a/fleet/query/utils.py
+++ b/fleet/query/utils.py
@@ -3,7 +3,12 @@ from os.path import isfile
 from configparser import ConfigParser
 
 from fleet_management_http_client_python import (
-    ApiClient, OrderApi, CarApi, PlatformHWApi, RouteApi, StopApi
+    ApiClient,
+    OrderApi,
+    CarApi,
+    PlatformHWApi,
+    RouteApi,
+    StopApi,
 )
 
 
@@ -25,7 +30,7 @@ def delete_all(api_client: ApiClient) -> None:
     for platform in platforms:
         print(f"Deleting platform {platform.id}, name: {platform.name}")
         platform_api.delete_hw(platform_hw_id=platform.id)
-    
+
     route_api = RouteApi(api_client)
     routes = route_api.get_routes()
     for route in routes:
@@ -48,12 +53,23 @@ def argument_parser_init() -> argparse.Namespace:
     argparse.Namespace : object with atributes
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('-c', '--config', type=str,
-                        help='Config file, default is config/config.ini', default='config/config.ini')
-    parser.add_argument('-m', '--maps', type=str,
-                        help='Directory with input files, default is maps/', default='maps/')
-    parser.add_argument('-d', '--delete', action='store_true',
-                        help='Delete all entities from database')
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        help="Config file, default is config/config.ini",
+        default="config/config.ini",
+    )
+    parser.add_argument(
+        "-m",
+        "--maps",
+        type=str,
+        help="Directory with input map config files, default is maps/",
+        default="maps/",
+    )
+    parser.add_argument(
+        "-d", "--delete", action="store_true", help="Delete all entities from database"
+    )
     return parser.parse_args()
 
 

--- a/main.py
+++ b/main.py
@@ -117,6 +117,14 @@ def run_queries(api_client: ApiClient, json_config_path: str, already_added_cars
         car_api.create_cars(new_cars)
 
 
+def create_tenant(api_client: ApiClient, tenant_name: str) -> None:
+    tenant_api = TenantApi(api_client)
+    try:
+        tenant_api.create_tenants([Tenant(name=tenant_name)])
+    except:
+        print(f"Tenant {tenant_name} already exists")
+
+
 def main() -> None:
     args = argument_parser_init()
     if not file_exists(args.config):
@@ -128,8 +136,6 @@ def main() -> None:
         ),
         cookie=f"tenant={config['DEFAULT']['Tenant']}",
     )
-    tenant_api = TenantApi(api_client)
-    tenant_api.create_tenants([Tenant(name=config['DEFAULT']['Tenant'])])
     args.maps = os.path.join(args.maps, "")
     if args.delete:
         delete_all(api_client)
@@ -138,6 +144,7 @@ def main() -> None:
     for map_file in glob.iglob(f"{args.maps}*"):
         print(f"\nProcessing file: {map_file}")
         try:
+            create_tenant(api_client, config["DEFAULT"]["Tenant"])
             run_queries(api_client, map_file, already_added_cars)
         except Exception as exception:
             print(exception)

--- a/main.py
+++ b/main.py
@@ -34,8 +34,8 @@ RouteName = str
 def run_queries(
     api_client: ApiClient, map_config_path: str, already_added_cars: list[CarName]
 ) -> None:
-    with open(map_config_path, "r", encoding="utf-8") as json_file:
-        map_config = json.load(json_file)
+    with open(map_config_path, "r", encoding="utf-8") as map_file:
+        map_config = json.load(map_file)
     stop_api = StopApi(api_client)
     new_stops = list()
 

--- a/main.py
+++ b/main.py
@@ -19,13 +19,14 @@ from fleet_management_http_client_python import (
     CarApi,
     Car,
     MobilePhone,
+    TenantApi,
+    Tenant,
 )
 
 
 def run_queries(api_client: ApiClient, json_config_path: str, already_added_cars: list) -> None:
     with open(json_config_path, "r", encoding="utf-8") as json_file:
         json_config = json.load(json_file)
-
     stop_api = StopApi(api_client)
     new_stops = list()
     for stop in json_config["stops"]:
@@ -127,7 +128,8 @@ def main() -> None:
         ),
         cookie=f"tenant={config['DEFAULT']['Tenant']}",
     )
-
+    tenant_api = TenantApi(api_client)
+    tenant_api.create_tenants([Tenant(name=config['DEFAULT']['Tenant'])])
     args.maps = os.path.join(args.maps, "")
     if args.delete:
         delete_all(api_client)

--- a/main.py
+++ b/main.py
@@ -37,9 +37,9 @@ def run_queries(
     with open(map_config_path, "r", encoding="utf-8") as map_file:
         map_config = json.load(map_file)
     stop_api = StopApi(api_client)
-    new_stops = list()
+    new_stops: list[Stop] = list()
 
-    tenant_name = map_config["tenant"]
+    tenant_name: str = map_config["tenant"]
     tenant_created = create_tenant(api_client, tenant_name)
     if not tenant_created:
         print(
@@ -99,8 +99,8 @@ def run_queries(
 
     platform_api = PlatformHWApi(api_client)
     car_api = CarApi(api_client)
-    new_platforms = list()
-    new_cars = list()
+    new_platforms: list[PlatformHW] = list()
+    new_cars: list[Car] = list()
     for platform in platform_api.get_hws():
         if platform.name not in already_added_cars:
             already_added_cars.append(platform.name)

--- a/main.py
+++ b/main.py
@@ -27,7 +27,12 @@ from fleet_management_http_client_python.exceptions import (
 )
 
 
-def run_queries(api_client: ApiClient, map_config_path: str, already_added_cars: list) -> None:
+CarName = str
+
+
+def run_queries(
+    api_client: ApiClient, map_config_path: str, already_added_cars: list[CarName]
+) -> None:
     with open(map_config_path, "r", encoding="utf-8") as json_file:
         map_config = json.load(json_file)
     stop_api = StopApi(api_client)
@@ -161,7 +166,7 @@ def main() -> None:
     if args.delete:
         delete_all(api_client)
         print("Fleet management deleted")
-    already_added_cars = list()
+    already_added_cars: list[CarName] = list()
     for map_file_path in glob.iglob(f"{args.maps}*"):
         print(f"\nProcessing file: {map_file_path}")
         try:

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ def run_queries(api_client: ApiClient, map_config_path: str, already_added_cars:
             f"Tenant '{tenant_name}' could not be created. Cannot create entities for map '{map_config_path}'"
         )
         return
-
+    api_client.set_default_header("Cookie", "tenant=" + tenant_name)
     for stop in map_config["stops"]:
         print(f"New stop, name: {stop['name']}")
         new_stops.append(
@@ -137,10 +137,10 @@ def create_tenant(api_client: ApiClient, tenant_name: str) -> bool:
     except _BadRequestException as e:
         response = tenant_api.get_tenants()
         tenant_already_exists = any(t.name == tenant_name for t in response)
-        if tenant_already_exists:
+        if not tenant_already_exists:
             print(f"Tenant '{tenant_name}' already exists.")
         else:
-            print(f"Could not create tenant '{tenant_name}'. Error: {e}")
+            print(f"Tenant '{tenant_name}' does not exists and could not be created. Error: {e}")
         return tenant_already_exists
     except Exception as exception:
         print(f"Could not create tenant '{tenant_name}' due to {exception}")

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ from fleet_management_http_client_python.exceptions import (
 
 
 CarName = str
+RouteName = str
 
 
 def run_queries(
@@ -60,12 +61,12 @@ def run_queries(
     created_stops = stop_api.create_stops(new_stops)
 
     route_api = RouteApi(api_client)
-    new_routes = list()
-    new_visualizations = list()
-    visualization_stops = dict()
+    new_routes: list[Route] = list()
+    new_visualizations: list[RouteVisualization] = list()
+    visualization_stops: dict[RouteName, list[GNSSPosition]] = dict()
     for route in map_config["routes"]:
         stops = route["stops"]
-        stop_ids = list()
+        stop_ids: list[int] = list()
         visualization_stops[route["name"]] = list()
         for stop in stops:
             visualization_stops[route["name"]].append(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests >= 2.26.0
 pydantic >= 2.7.1
 python-dateutil >= 2.9.0.post0
-fleet_management_http_client_python @ git+https://github.com/bringauto/fleet-management-http-client-python.git@v4.0.0
+fleet_management_http_client_python @ git+https://github.com/bringauto/fleet-management-http-client-python.git@v4.1.0


### PR DESCRIPTION
The fleet-init script now uses the post method for /tenant endpoint. If the tenant already exists, a message is printed to the console - nothing else happens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The application now ensures that a tenant is created or confirmed before processing queries for each map file.

- **Documentation**
  - Improved formatting and syntax highlighting for the configuration example in the README.

- **Chores**
  - Updated a dependency to a newer version for improved compatibility and features.
  - Removed tenant information from the default configuration file to streamline setup.

- **Style**
  - Enhanced code readability by reformatting import statements and argument definitions.
  - Clarified help text for map configuration input directory in command-line arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->