### PR TITLE
Baf 1185/fix deleting with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,12 @@ Example run:
 python3 main.py -c config/config.ini -m maps -d
 ```
 
+### Testing
+
+To run the script in test mode (no requests to the server), use the `-t` or `--test` flag:
+
+```python
+python3 main.py -c config/config.ini -m maps -d -t
+```
+
 [BringAuto Fleet Management]: https://github.com/bringauto/fleet-management-http-api

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ python3 main.py -c config/config.ini -m maps -d
 
 ### Testing
 
-To run the script in test mode (no requests to the server), use the `-t` or `--test` flag:
+To run the script in test mode (no requests to the server), use the `-t` or `--test` flag. Note that in test mode, the script
+always simulates accessible server, with no data.
 
 ```bash
 python3 main.py -c config/config.ini -m maps -d -t

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ All parameters in `DEFAULT` section are required to let the script work.
 
 Install requirements:
 
-```
+```bash
 pip3 install -r requirements.txt
 ```
 
 Example run:
 
-```
+```bash
 python3 main.py -c config/config.ini -m maps -d
 ```
 
@@ -46,7 +46,7 @@ python3 main.py -c config/config.ini -m maps -d
 
 To run the script in test mode (no requests to the server), use the `-t` or `--test` flag:
 
-```python
+```bash
 python3 main.py -c config/config.ini -m maps -d -t
 ```
 

--- a/config/config.ini
+++ b/config/config.ini
@@ -1,3 +1,3 @@
 [DEFAULT]
-ApiKey = <ApiKey>
-Url = 127.0.0.1:8080/v2/management
+ApiKey = uOCIPuVUteDsAfwsFimWswXiVVKFDk
+Url = 127.0.0.1:8081/v2/management

--- a/fleet/models.py
+++ b/fleet/models.py
@@ -1,0 +1,8 @@
+import pydantic
+
+
+class Map(pydantic.BaseModel):
+    tenant: str
+    cars: list
+    stops: list
+    routes: list

--- a/fleet/query/client.py
+++ b/fleet/query/client.py
@@ -20,10 +20,13 @@ from fleet_management_http_client_python import (  # type: ignore
 class ManagementApiClient:
     """Wrapper for HTTP Client for simpler usage and testability"""
 
-    def __init__(self, host: str, api_key: dict[str, str]) -> None:
+    def __init__(self, host: str, api_key: dict[str, str], test: bool) -> None:
         configuration = Configuration(host=host, api_key=api_key)
         api_client = ApiClient(configuration)
         self.api_client = api_client
+
+        self.test = test
+
         self.stop_api = StopApi(api_client)
         self.route_api = RouteApi(api_client)
         self.platform_api = PlatformHWApi(api_client)
@@ -31,58 +34,94 @@ class ManagementApiClient:
         self.tenant_api = TenantApi(api_client)
         self.order_api = OrderApi(api_client)
 
+    def _entities_with_set_id(self, entities: list) -> list:
+        for k, entity in enumerate(entities):
+            entity.id = k
+        return entities
+
     def create_stops(self, stops: list[Stop]) -> list[Stop]:
+        if self.test:
+            return self._entities_with_set_id(stops)
         return self.stop_api.create_stops(stops)
 
     def create_routes(self, routes: list[Route]) -> list[Route]:
+        if self.test:
+            return self._entities_with_set_id(routes)
         return self.route_api.create_routes(routes)
 
     def get_routes(self) -> list[Route]:
+        if self.test:
+            return []
         return self.route_api.get_routes()
 
     def delete_route(self, route_id: int) -> None:
+        if self.test:
+            return
         self.route_api.delete_route(route_id=route_id)
 
     def get_stops(self) -> list[Stop]:
+        if self.test:
+            return []
         return self.stop_api.get_stops()
 
     def delete_stop(self, stop_id: int) -> None:
+        if self.test:
+            return
         self.stop_api.delete_stop(stop_id=stop_id)
 
     def redefine_route_visualizations(self, visualizations: list[RouteVisualization]) -> None:
+        if self.test:
+            return
         self.route_api.redefine_route_visualizations(visualizations)
 
-    def get_platforms(self) -> list[PlatformHW]:
-        return self.platform_api.get_hws()
-
     def get_orders(self) -> list[Order]:
+        if self.test:
+            return []
         return self.order_api.get_orders()
 
     def delete_order(self, car_id: int, order_id: int) -> None:
+        if self.test:
+            return
         self.order_api.delete_order(car_id=car_id, order_id=order_id)
 
     def create_hws(self, platforms: list[PlatformHW]) -> list[PlatformHW]:
+        if self.test:
+            return self._entities_with_set_id(platforms)
         return self.platform_api.create_hws(platforms)
 
     def delete_hw(self, platform_hw_id: int) -> None:
+        if self.test:
+            return
         self.platform_api.delete_hw(platform_hw_id=platform_hw_id)
 
     def create_cars(self, cars: list[Car]) -> list[Car]:
+        if self.test:
+            return self._entities_with_set_id(cars)
         return self.car_api.create_cars(cars)
 
     def delete_car(self, car_id: int) -> None:
+        if self.test:
+            return
         self.car_api.delete_car(car_id=car_id)
 
     def get_tenants(self) -> list[Tenant]:
+        if self.test:
+            return []
         return self.tenant_api.get_tenants()
 
     def create_tenants(self, tenants: list[Tenant]) -> list[Tenant]:
+        if self.test:
+            return self._entities_with_set_id(tenants)
         return self.tenant_api.create_tenants(tenants)
 
     def delete_tenant(self, tenant_id: int) -> None:
+        if self.test:
+            return
         self.tenant_api.delete_tenant(tenant_id)
 
     def set_tenant_cookie_with_http_info(self, tenant_id: int) -> str | None:
+        if self.test:
+            return "test_cookie"
         try:
             cookie_response = self.tenant_api.set_tenant_cookie_with_http_info(tenant_id)
             return cookie_response.headers.get("Set-Cookie")
@@ -91,10 +130,16 @@ class ManagementApiClient:
             return None
 
     def get_cars(self) -> list[Car]:
+        if self.test:
+            return []
         return self.car_api.get_cars()
 
     def get_hws(self) -> list[PlatformHW]:
+        if self.test:
+            return []
         return self.platform_api.get_hws()
 
     def set_default_header(self, header_name: str, header_value: str) -> None:
+        if self.test:
+            return
         self.api_client.set_default_header(header_name, header_value)

--- a/fleet/query/client.py
+++ b/fleet/query/client.py
@@ -1,0 +1,100 @@
+from fleet_management_http_client_python import (  # type: ignore
+    Configuration,
+    ApiClient,
+    StopApi,
+    Stop,
+    OrderApi,
+    Order,
+    RouteApi,
+    Route,
+    RouteVisualization,
+    PlatformHWApi,
+    PlatformHW,
+    CarApi,
+    Car,
+    TenantApi,
+    Tenant,
+)
+
+
+class ManagementApiClient:
+    """Wrapper for HTTP Client for simpler usage and testability"""
+
+    def __init__(self, host: str, api_key: dict[str, str]) -> None:
+        configuration = Configuration(host=host, api_key=api_key)
+        api_client = ApiClient(configuration)
+        self.api_client = api_client
+        self.stop_api = StopApi(api_client)
+        self.route_api = RouteApi(api_client)
+        self.platform_api = PlatformHWApi(api_client)
+        self.car_api = CarApi(api_client)
+        self.tenant_api = TenantApi(api_client)
+        self.order_api = OrderApi(api_client)
+
+    def create_stops(self, stops: list[Stop]) -> list[Stop]:
+        return self.stop_api.create_stops(stops)
+
+    def create_routes(self, routes: list[Route]) -> list[Route]:
+        return self.route_api.create_routes(routes)
+
+    def get_routes(self) -> list[Route]:
+        return self.route_api.get_routes()
+
+    def delete_route(self, route_id: int) -> None:
+        self.route_api.delete_route(route_id=route_id)
+
+    def get_stops(self) -> list[Stop]:
+        return self.stop_api.get_stops()
+
+    def delete_stop(self, stop_id: int) -> None:
+        self.stop_api.delete_stop(stop_id=stop_id)
+
+    def redefine_route_visualizations(self, visualizations: list[RouteVisualization]) -> None:
+        self.route_api.redefine_route_visualizations(visualizations)
+
+    def get_platforms(self) -> list[PlatformHW]:
+        return self.platform_api.get_hws()
+
+    def get_orders(self) -> list[Order]:
+        return self.order_api.get_orders()
+
+    def delete_order(self, car_id: int, order_id: int) -> None:
+        self.order_api.delete_order(car_id=car_id, order_id=order_id)
+
+    def create_hws(self, platforms: list[PlatformHW]) -> list[PlatformHW]:
+        return self.platform_api.create_hws(platforms)
+
+    def delete_hw(self, platform_hw_id: int) -> None:
+        self.platform_api.delete_hw(platform_hw_id=platform_hw_id)
+
+    def create_cars(self, cars: list[Car]) -> list[Car]:
+        return self.car_api.create_cars(cars)
+
+    def delete_car(self, car_id: int) -> None:
+        self.car_api.delete_car(car_id=car_id)
+
+    def get_tenants(self) -> list[Tenant]:
+        return self.tenant_api.get_tenants()
+
+    def create_tenants(self, tenants: list[Tenant]) -> list[Tenant]:
+        return self.tenant_api.create_tenants(tenants)
+
+    def delete_tenant(self, tenant_id: int) -> None:
+        self.tenant_api.delete_tenant(tenant_id)
+
+    def set_tenant_cookie_with_http_info(self, tenant_id: int) -> str | None:
+        try:
+            cookie_response = self.tenant_api.set_tenant_cookie_with_http_info(tenant_id)
+            return cookie_response.headers.get("Set-Cookie")
+        except Exception as exception:
+            print(f"Could not set tenant cookie due to {exception}")
+            return None
+
+    def get_cars(self) -> list[Car]:
+        return self.car_api.get_cars()
+
+    def get_hws(self) -> list[PlatformHW]:
+        return self.platform_api.get_hws()
+
+    def set_default_header(self, header_name: str, header_value: str) -> None:
+        self.api_client.set_default_header(header_name, header_value)

--- a/fleet/query/utils.py
+++ b/fleet/query/utils.py
@@ -78,6 +78,12 @@ def argument_parser_init() -> argparse.Namespace:
         action="store_true",
         help="Delete all entities from database",
     )
+    parser.add_argument(
+        "-t",
+        "--test",
+        action="store_true",
+        help="Run in test mode (no requests to the server)",
+    )
     return parser.parse_args()
 
 

--- a/fleet/query/utils.py
+++ b/fleet/query/utils.py
@@ -2,59 +2,49 @@ import argparse
 from os.path import isfile
 from configparser import ConfigParser
 
-from fleet_management_http_client_python import ( # type: ignore
-    ApiClient,
-    OrderApi,
-    CarApi,
-    PlatformHWApi,
-    RouteApi,
-    StopApi,
-)
+from fleet.query.client import ManagementApiClient
 
 
-def delete_all(api_client: ApiClient) -> None:
-    order_api = OrderApi(api_client)
-    orders = order_api.get_orders()
+def delete_all(api_client: ManagementApiClient) -> None:
+    orders = api_client.get_orders()
     for order in orders:
         print(f"Deleting order {order.id}")
         try:
-            order_api.delete_order(car_id=order.car_id, order_id=order.id)
+            api_client.delete_order(car_id=order.car_id, order_id=order.id)
         except Exception:
             print(f"Failed to delete order {order.id}, possibly belongs to a different tenant.")
 
-    car_api = CarApi(api_client)
-    cars = car_api.get_cars()
+    cars = api_client.get_cars()
     for car in cars:
         print(f"Deleting car {car.id}, name: {car.name}")
         try:
-            car_api.delete_car(car_id=car.id)
+            api_client.delete_car(car_id=car.id)
         except Exception:
             print(f"Failed to delete car {car.id}, possibly belongs to a different tenant.")
 
-    platform_api = PlatformHWApi(api_client)
-    platforms = platform_api.get_hws()
+    platforms = api_client.get_hws()
     for platform in platforms:
         print(f"Deleting platform {platform.id}, name: {platform.name}")
         try:
-            platform_api.delete_hw(platform_hw_id=platform.id)
+            api_client.delete_hw(platform_hw_id=platform.id)
         except Exception:
-            print(f"Failed to delete platform {platform.id}, possibly belongs to a different tenant.")
+            print(
+                f"Failed to delete platform {platform.id}, possibly belongs to a different tenant."
+            )
 
-    route_api = RouteApi(api_client)
-    routes = route_api.get_routes()
+    routes = api_client.get_routes()
     for route in routes:
         print(f"Deleting route {route.id}, name: {route.name}")
         try:
-            route_api.delete_route(route_id=route.id)
+            api_client.delete_route(route_id=route.id)
         except Exception:
             print(f"Failed to delete route {route.id}, possibly belongs to a different tenant.")
 
-    stop_api = StopApi(api_client)
-    stops = stop_api.get_stops()
+    stops = api_client.get_stops()
     for stop in stops:
         print(f"Deleting stop {stop.id}, name: {stop.name}")
         try:
-            stop_api.delete_stop(stop_id=stop.id)
+            api_client.delete_stop(stop_id=stop.id)
         except Exception:
             print(f"Failed to delete stop {stop.id}, possibly belongs to a different tenant.")
 

--- a/main.py
+++ b/main.py
@@ -133,8 +133,11 @@ def main() -> None:
     if not file_exists(args.config):
         raise IOError(f"Input config file does not exist: {args.config}")
     config = config_parser_init(args.config)
+
     api_client = ManagementApiClient(
-        host=config["DEFAULT"]["Url"], api_key={"APIKeyAuth": config["DEFAULT"]["ApiKey"]}
+        host=config["DEFAULT"]["Url"],
+        api_key={"APIKeyAuth": config["DEFAULT"]["ApiKey"]},
+        test=args.test,
     )
 
     args.maps = os.path.join(args.maps, "")

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import json
 import os
 
 from fleet import argument_parser_init, config_parser_init, delete_all, file_exists
-from fleet_management_http_client_python import ( # type: ignore
+from fleet_management_http_client_python import (  # type: ignore
     ApiClient,
     Configuration,
     StopApi,
@@ -22,18 +22,13 @@ from fleet_management_http_client_python import ( # type: ignore
     TenantApi,
     Tenant,
 )
-from fleet_management_http_client_python.exceptions import ( # type: ignore
-    BadRequestException as _BadRequestException,
-)
 
 
 CarName = str
 RouteName = str
 
 
-def run_queries(
-    api_client: ApiClient, map_config: dict, already_added_cars: list[CarName]
-) -> None:
+def run_queries(api_client: ApiClient, map_config: dict, already_added_cars: list[CarName]) -> None:
     stop_api = StopApi(api_client)
     new_stops: list[Stop] = list()
 

--- a/maps/brno.json
+++ b/maps/brno.json
@@ -53,7 +53,7 @@
           "stationName": "Drobného"
         },
         {
-          "latitude": 49.2050110,
+          "latitude": 49.205011,
           "longitude": 16.6133782,
           "stationName": null
         },
@@ -68,7 +68,7 @@
           "stationName": null
         },
         {
-          "latitude": 49.2052230,
+          "latitude": 49.205223,
           "longitude": 16.6133275,
           "stationName": null
         },
@@ -113,13 +113,13 @@
           "stationName": null
         },
         {
-          "latitude": 49.2064690,
+          "latitude": 49.206469,
           "longitude": 16.6124238,
           "stationName": null
         },
         {
           "latitude": 49.2067984,
-          "longitude": 16.6120000,
+          "longitude": 16.612,
           "stationName": null
         },
         {
@@ -134,7 +134,7 @@
         },
         {
           "latitude": 49.2074205,
-          "longitude": 16.6111980,
+          "longitude": 16.611198,
           "stationName": null
         },
         {
@@ -193,17 +193,17 @@
           "stationName": null
         },
         {
-          "latitude": 49.2092570,
+          "latitude": 49.209257,
           "longitude": 16.6090858,
           "stationName": null
         },
         {
           "latitude": 49.2092289,
-          "longitude": 16.6088390,
+          "longitude": 16.608839,
           "stationName": null
         },
         {
-          "latitude": 49.2091290,
+          "latitude": 49.209129,
           "longitude": 16.6085735,
           "stationName": null
         },
@@ -228,18 +228,18 @@
           "stationName": null
         },
         {
-          "latitude": 49.2085990,
+          "latitude": 49.208599,
           "longitude": 16.6071023,
           "stationName": null
         },
         {
           "latitude": 49.2084193,
-          "longitude": 16.6065980,
+          "longitude": 16.606598,
           "stationName": null
         },
         {
           "latitude": 49.2083195,
-          "longitude": 16.6063070,
+          "longitude": 16.606307,
           "stationName": null
         },
         {
@@ -254,11 +254,11 @@
         },
         {
           "latitude": 49.2079094,
-          "longitude": 16.6050410,
+          "longitude": 16.605041,
           "stationName": null
         },
         {
-          "latitude": 49.2077780,
+          "latitude": 49.207778,
           "longitude": 16.6045046,
           "stationName": null
         },
@@ -358,13 +358,13 @@
           "stationName": null
         },
         {
-          "latitude": 49.2041190,
+          "latitude": 49.204119,
           "longitude": 16.6067254,
           "stationName": "Lidická"
         },
         {
           "latitude": 49.2042303,
-          "longitude": 16.6072310,
+          "longitude": 16.607231,
           "stationName": null
         },
         {


### PR DESCRIPTION
The fleet-init script is relatively simple, but anyway it is still useful to have the option to test it at some level, even without fleet management http server running. This option has been added. 

Minor refactors have been done (literals instead of calls for list initialization etc.).

Minor bug has been fixed (common list of already created car names used accross all tenants - separate lists must be used for each tenant, as the car names may repeat accross tenants).

